### PR TITLE
Introduce standalone entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.
 main.js
+dist
 
 # Exclude sourcemaps
 *.map

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,4 @@
+{
+  "botToken": "YOUR_BOT_TOKEN_HERE",
+  "vaultPath": "./vault"
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
 		"test": "node esbuild.config.mjs test && npm run post-build && node install-plugin.mjs",
 		"release-notes-check": "node release-notes.mjs check",
 		"build": "tsc -noEmit -skipLibCheck && npm run lint && node esbuild.config.mjs production && npm run post-build",
-		"post-build": "node post-build.mjs"
+                "post-build": "node post-build.mjs",
+                "build-standalone": "tsc -p tsconfig.standalone.json",
+                "start": "npm run build-standalone && node dist/standalone/index.js"
 	},
 	"keywords": [
 		"Telegram",

--- a/src/standalone/config.ts
+++ b/src/standalone/config.ts
@@ -1,0 +1,15 @@
+import { promises as fs } from 'fs';
+
+export interface StandaloneConfig {
+  botToken: string;
+  vaultPath: string;
+}
+
+export async function loadConfig(path: string): Promise<StandaloneConfig> {
+  const data = await fs.readFile(path, 'utf8');
+  return JSON.parse(data) as StandaloneConfig;
+}
+
+export async function saveConfig(path: string, config: StandaloneConfig): Promise<void> {
+  await fs.writeFile(path, JSON.stringify(config, null, 2), 'utf8');
+}

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -1,0 +1,16 @@
+import { loadConfig } from './config';
+
+async function main() {
+  const configArgIndex = process.argv.indexOf('--config');
+  const configPath = configArgIndex !== -1 && process.argv[configArgIndex + 1] ? process.argv[configArgIndex + 1] : 'config.json';
+  try {
+    const cfg = await loadConfig(configPath);
+    console.log('Telegram Sync started with config:', configPath);
+    console.log(cfg);
+  } catch (err) {
+    console.error('Failed to load config', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tsconfig.standalone.json
+++ b/tsconfig.standalone.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/standalone/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "./dist/standalone",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "module": "CommonJS",
+    "target": "ES2020"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample JSON config
- add standalone TypeScript entry and config loader
- compile standalone script via new tsconfig
- add start/build-standalone npm scripts
- ignore dist folder

## Testing
- `npm run build-standalone`
- `npm start -- --config config.example.json`

------
https://chatgpt.com/codex/tasks/task_e_68553216ee28832fbfff55ba74d6784d