### PR TITLE
Implement config resource

### DIFF
--- a/my-bot/src/main/java/ru/nikkitavr/tfs/infra/web/resource/MessageAssistantConfigurationResource.java
+++ b/my-bot/src/main/java/ru/nikkitavr/tfs/infra/web/resource/MessageAssistantConfigurationResource.java
@@ -1,32 +1,92 @@
 package ru.nikkitavr.tfs.infra.web.resource;
 
-import org.apache.commons.lang3.NotImplementedException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import ru.nikkitavr.tfs.config.AppConfig;
+import ru.nikkitavr.tfs.model.MessageAssistantConfiguration;
+import ru.nikkitavr.tfs.service.MessageAssistantConfigurationProvider;
 
 @RestController
 @RequestMapping("/message-assistant-bot/config")
 public class MessageAssistantConfigurationResource {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(MessageAssistantConfigurationResource.class);
+
+  private final ObjectMapper objectMapper;
+  private final MessageAssistantConfigurationProvider configurationProvider;
+
+  public MessageAssistantConfigurationResource(ObjectMapper objectMapper,
+      MessageAssistantConfigurationProvider configurationProvider) {
+    this.objectMapper = objectMapper;
+    this.configurationProvider = configurationProvider;
+  }
+
+  /** Returns current configuration as json string. */
   @GetMapping
   public ResponseEntity<String> getConfig() {
-    throw new NotImplementedException();
-    //TODO: get config from data folder (AppConfig.MESSAGE_ASSISTANT_CONFIG_PATH)
+    try {
+      Path path = Path.of(AppConfig.MESSAGE_ASSISTANT_CONFIG_PATH);
+      if (!Files.exists(path)) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+      }
+      String json = Files.readString(path);
+      return ResponseEntity.ok(json);
+    } catch (IOException e) {
+      LOGGER.error("Error reading configuration", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 
+  /**
+   * Replaces configuration with new json provided in request body.
+   * The provider is updated with the parsed configuration.
+   */
   @PostMapping
   public ResponseEntity<Void> updateConfig(@RequestBody String jsonBody) {
-    throw new NotImplementedException();
-    //TODO: replace config in data folder (AppConfig.MESSAGE_ASSISTANT_CONFIG_PATH)
+    try {
+      MessageAssistantConfiguration config =
+          objectMapper.readValue(jsonBody, MessageAssistantConfiguration.class);
+
+      Path configPath = Path.of(AppConfig.MESSAGE_ASSISTANT_CONFIG_PATH);
+      Files.createDirectories(configPath.getParent());
+      Files.writeString(configPath, jsonBody);
+
+      configurationProvider.update(config);
+      return ResponseEntity.ok().build();
+    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      LOGGER.error("Invalid configuration JSON", e);
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    } catch (IOException e) {
+      LOGGER.error("Error writing configuration", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 
+  /** Returns default configuration bundled with the application. */
   @GetMapping("/default")
   public ResponseEntity<String> getDefaultConfig() {
-    throw new NotImplementedException();
-    //TODO: get default config from resource folder (AppConfig.MESSAGE_ASSISTANT_DEFAULT_CONFIG_PATH_RSX)
+    try (InputStream is =
+             getClass().getClassLoader().getResourceAsStream(AppConfig.MESSAGE_ASSISTANT_DEFAULT_CONFIG_PATH_RSX)) {
+      if (is == null) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+      }
+      String json = new String(is.readAllBytes());
+      return ResponseEntity.ok(json);
+    } catch (IOException e) {
+      LOGGER.error("Error reading default configuration", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
   }
 }

--- a/my-bot/src/main/java/ru/nikkitavr/tfs/service/MessageAssistantService.java
+++ b/my-bot/src/main/java/ru/nikkitavr/tfs/service/MessageAssistantService.java
@@ -1,32 +1,140 @@
 package ru.nikkitavr.tfs.service;
 
-import org.apache.commons.lang3.NotImplementedException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ru.nikkitavr.tfs.model.Message;
 import ru.nikkitavr.tfs.model.MessageAssistantConfiguration;
 import static ru.nikkitavr.tfs.model.MessageAssistantConfiguration.DistributionRule;
 import ru.nikkitavr.tfs.utils.FileSystemUtils;
+import ru.nikkitavr.tfs.utils.TemplateUtils;
 
 public class MessageAssistantService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MessageAssistantService.class);
+
   private final MessageAssistantConfigurationProvider configProvider;
   private final FileSystemUtils fileSystemUtils;
 
-  public MessageAssistantService(MessageAssistantConfigurationProvider configProvider, FileSystemUtils fileSystemUtils) {
+  public MessageAssistantService(MessageAssistantConfigurationProvider configProvider,
+      FileSystemUtils fileSystemUtils) {
     this.configProvider = configProvider;
     this.fileSystemUtils = fileSystemUtils;
   }
 
+  /**
+   * Process incoming message and store it according to configuration rules.
+   */
   public void processMessage(Message message) {
-    //TODO: добавить обработку и сохранение сообщения на основании конфигурации MessageAssistantConfiguration и данных в Message. С учетом шаблонов.
     MessageAssistantConfiguration config = configProvider.get();
-    DistributionRule distributionRule = getFirstMatchedRule(config, message);
-    //TODO: После получения правила - нужно сохранить message как .md файл (или записать в существующий) с учетом настроек distributionRule
+    if (config == null || config.getDistributionRules() == null) {
+      return;
+    }
 
+    DistributionRule rule = getFirstMatchedRule(config, message);
+    if (rule == null) {
+      return;
+    }
+
+    String template;
+    if (rule.getTemplatePath() != null && !rule.getTemplatePath().isBlank()) {
+      Path tplPath = Path.of(config.getVaultPath(), rule.getTemplatePath());
+      try {
+        template = Files.readString(tplPath);
+      } catch (IOException e) {
+        LOGGER.error("Failed to read template {}", tplPath, e);
+        template = "{{content}}";
+      }
+    } else {
+      template = "{{content}}";
+    }
+
+    String noteContent = TemplateUtils.apply(template, message) + System.lineSeparator();
+
+    if (rule.getNotePathTemplate() != null && !rule.getNotePathTemplate().isBlank()) {
+      String notePathStr = TemplateUtils.apply(rule.getNotePathTemplate(), message);
+      Path notePath = Path.of(config.getVaultPath(), notePathStr);
+      try {
+        fileSystemUtils.appendToFile(notePath, noteContent);
+      } catch (IOException e) {
+        LOGGER.error("Failed to write note {}", notePath, e);
+      }
+    }
   }
 
   private DistributionRule getFirstMatchedRule(MessageAssistantConfiguration config, Message message) {
-    //TODO: Метод должен вернуть первый DistributionRule из конфига, совпавший по полю messageFilterQuery с контентом сообщения на основе шаблона
-    // см. ConditionType, ConditionOperation в obsidian-plugin
-    throw new NotImplementedException();
+    List<DistributionRule> rules = config.getDistributionRules();
+    if (rules == null) {
+      return null;
+    }
+
+    for (DistributionRule rule : rules) {
+      if (matches(rule.getMessageFilterQuery(), message)) {
+        return rule;
+      }
+    }
+    return null;
+  }
+
+  private boolean matches(String query, Message message) {
+    if (query == null || query.isBlank()) {
+      return true;
+    }
+    Pattern pattern = Pattern.compile("\\{\\{([^=~]+)(=|~)([^}]+)\\}}");
+    Matcher matcher = pattern.matcher(query);
+    while (matcher.find()) {
+      String key = matcher.group(1);
+      String op = matcher.group(2);
+      String value = matcher.group(3);
+
+      if (!matchCondition(key, op, value, message)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean matchCondition(String key, String op, String value, Message message) {
+    switch (key) {
+      case "chat":
+        if (message.getChat() == null) return false;
+        String chatName = message.getChat().getTitle();
+        if (chatName == null || chatName.isEmpty()) {
+          chatName = message.getChat().getFirstName();
+        }
+        String chatId = String.valueOf(message.getChat().getId());
+        return compare(chatName, value, op) || compare(chatId, value, op);
+      case "user":
+        if (message.getFrom() == null) return false;
+        String username = message.getFrom().getUserName();
+        String fullName = (message.getFrom().getFirstName() + " " +
+            (message.getFrom().getLastName() != null ? message.getFrom().getLastName() : "")).trim();
+        String userId = String.valueOf(message.getFrom().getId());
+        return compare(username, value, op) || compare(fullName, value, op) || compare(userId, value, op);
+      case "content":
+        String text = message.getText();
+        if (text == null) text = message.getCaption();
+        return compare(text, value, op);
+      case "topic":
+        if (message.getMessageThreadId() == null) return false;
+        return compare(String.valueOf(message.getMessageThreadId()), value, op);
+      default:
+        return false;
+    }
+  }
+
+  private boolean compare(String actual, String expected, String op) {
+    if (actual == null) return false;
+    if ("=".equals(op)) {
+      return actual.equals(expected);
+    } else if ("~".equals(op)) {
+      return actual.contains(expected);
+    }
+    return false;
   }
 
 }

--- a/my-bot/src/main/java/ru/nikkitavr/tfs/utils/FileSystemUtils.java
+++ b/my-bot/src/main/java/ru/nikkitavr/tfs/utils/FileSystemUtils.java
@@ -1,4 +1,55 @@
 package ru.nikkitavr.tfs.utils;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
 public class FileSystemUtils {
+
+  /** Ensure that the parent directories for the given file exist. */
+  public void ensureParentExists(Path file) throws IOException {
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+  }
+
+  /**
+   * Append text to the file or create a new file if it does not exist.
+   */
+  public void appendToFile(Path file, String content) throws IOException {
+    ensureParentExists(file);
+    if (Files.exists(file)) {
+      Files.writeString(file, content, StandardOpenOption.APPEND);
+    } else {
+      Files.writeString(file, content);
+    }
+  }
+
+  /**
+   * Returns a unique file path by appending increasing numbers if needed.
+   */
+  public Path getUniqueFilePath(Path file) {
+    if (!Files.exists(file)) {
+      return file;
+    }
+    String fileName = file.getFileName().toString();
+    String baseName = fileName;
+    String ext = "";
+    int dot = fileName.lastIndexOf('.');
+    if (dot != -1) {
+      baseName = fileName.substring(0, dot);
+      ext = fileName.substring(dot);
+    }
+    int index = 1;
+    Path parent = file.getParent();
+    Path candidate;
+    do {
+      String newName = baseName + "-" + index + ext;
+      candidate = parent == null ? Path.of(newName) : parent.resolve(newName);
+      index++;
+    } while (Files.exists(candidate));
+    return candidate;
+  }
 }

--- a/my-bot/src/main/java/ru/nikkitavr/tfs/utils/TemplateUtils.java
+++ b/my-bot/src/main/java/ru/nikkitavr/tfs/utils/TemplateUtils.java
@@ -1,0 +1,59 @@
+package ru.nikkitavr.tfs.utils;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import ru.nikkitavr.tfs.model.Message;
+
+/** Simple template processor for {{variable}} placeholders. */
+public class TemplateUtils {
+
+  public static String apply(String template, Message message) {
+    if (template == null || template.isEmpty()) {
+      return "";
+    }
+    String result = template;
+    if (message.getText() != null) {
+      result = result.replace("{{content}}", message.getText());
+    } else if (message.getCaption() != null) {
+      result = result.replace("{{content}}", message.getCaption());
+    } else {
+      result = result.replace("{{content}}", "");
+    }
+
+    Instant messageDate = message.getDate();
+    if (messageDate != null) {
+      result = replaceDateVar(result, "messageDate", messageDate);
+      result = replaceDateVar(result, "messageTime", messageDate);
+    }
+    Instant now = Instant.now();
+    result = replaceDateVar(result, "date", now);
+    result = replaceDateVar(result, "time", now);
+
+    if (message.getChat() != null) {
+      String chatName = message.getChat().getTitle();
+      if (chatName == null || chatName.isEmpty()) {
+        chatName = message.getChat().getFirstName();
+      }
+      if (chatName != null) {
+        result = result.replace("{{chat:name}}", chatName);
+      }
+    }
+    return result;
+  }
+
+  private static String replaceDateVar(String text, String var, Instant value) {
+    int idx;
+    while ((idx = text.indexOf("{{" + var + ":")) != -1) {
+      int end = text.indexOf("}}", idx);
+      if (end == -1) {
+        break;
+      }
+      String format = text.substring(idx + var.length() + 3, end);
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault());
+      String formatted = formatter.format(value);
+      text = text.substring(0, idx) + formatted + text.substring(end + 2);
+    }
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- implement REST endpoint for bot configuration
- return BAD_REQUEST when JSON is invalid
- store configuration in the data directory
- implement basic message processing, template engine, and file utilities

## Testing
- `mvn -f my-bot/pom.xml test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6856b8de5848832fa36d107c86913a5c